### PR TITLE
feat: tail-recursive array parsing

### DIFF
--- a/src/Parse.flix
+++ b/src/Parse.flix
@@ -99,26 +99,27 @@ mod Json.Parse {
         case _ =>
             region rc {
                 let lst = MutList.new(rc);
-                def walk(input) =
-                    match value(input) {
+                def walk(input) = {
+                    let opt = forM(
+                        (val, tail) <- value(input);
+                        (_, tail1) <- whitespace(tail)
+                    ) yield (val, tail1);
+                    match opt {
                         case None => None
-                        case Some(val, tail) =>
+                        case Some(val, tail1) =>
                             MutList.push!(val, lst);
-                            match whitespace(tail) {
-                                case None => None
-                                case Some(_, tail1) =>
-                                    match tail1 {
-                                        case ']' :: _ => Some(tail1)
-                                        case ',' :: tail2 =>
-                                            match whitespace(tail2) {
-                                                case None => None
-                                                case Some(_, tail3) => walk(tail3)
-                                            }
-                                        case _ => None
+                            match tail1 {
+                                case ']' :: _ => Some(tail1)
+                                case ',' :: tail2 =>
+                                    match whitespace(tail2) {
+                                        case None => None
+                                        case Some(_, tail3) => walk(tail3)
                                     }
+                                case _ => None
                             }
-                    };
-                for(tl <- walk(in))
+                    }
+                };
+                forM(tl <- walk(in))
                     yield (MutList.toList(lst), tl)
             }
     }

--- a/src/Parse.flix
+++ b/src/Parse.flix
@@ -114,7 +114,10 @@ mod Json.Parse {
                                                 case None => None
                                                 case Some(_, tail3) => walk(tail3)
                                             }
-                                        case _ => None }}};
+                                        case _ => None
+                                    }
+                            }
+                    };
                 for(tl <- walk(in))
                     yield (MutList.toList(lst), tl)
             }

--- a/src/Parse.flix
+++ b/src/Parse.flix
@@ -115,10 +115,8 @@ mod Json.Parse {
                                                 case Some(_, tail3) => walk(tail3)
                                             }
                                         case _ => None }}};
-                match walk(in) {
-                    case None => None
-                    case Some(tl) => Some(MutList.toList(lst), tl)
-                }
+                for(tl <- walk(in))
+                    yield (MutList.toList(lst), tl)
             }
     }
 

--- a/src/Parse.flix
+++ b/src/Parse.flix
@@ -97,25 +97,28 @@ mod Json.Parse {
     def elements(in: List[Char]): ParseMonad[List[JsonElement]] = match in {
         case ']' :: _ => Some(Nil, in)
         case _ =>
-            for (
-                (val, tail) <- value(in);
-                (_, tail1) <- whitespace(tail);
-                res <- match tail1 {
-                    case ',' :: tail2 =>
-                        for (
-                            (_, tail3) <- whitespace(tail2);
-                            (rest, tail4) <- elements(tail3)
-                        ) yield {
-                            let list = val :: rest;
-                            (list, tail4)
-                        }
-                    case ']' :: _ =>
-                        let list = val :: Nil;
-                        Some(list, tail1)
-                    case _ => None
+            region rc {
+                let lst = MutList.new(rc);
+                def walk(input) =
+                    match value(input) {
+                        case None => None
+                        case Some(val, tail) =>
+                            MutList.push!(val, lst);
+                            match whitespace(tail) {
+                                case None => None
+                                case Some(_, tail1) =>
+                                    match tail1 {
+                                        case ']' :: _ => Some(tail1)
+                                        case ',' :: tail2 =>
+                                            match whitespace(tail2) {
+                                                case None => None
+                                                case Some(_, tail3) => walk(tail3)
+                                            }
+                                        case _ => None }}};
+                match walk(in) {
+                    case None => None
+                    case Some(tl) => Some(MutList.toList(lst), tl)
                 }
-            ) yield {
-                res
             }
     }
 

--- a/test/TestParse.flix
+++ b/test/TestParse.flix
@@ -52,41 +52,34 @@ mod TestParse {
         parse("{\"key\": \"\\a\"}") == None
     }
 
-    def toIntOpt(e:Json.JsonElement): Option[Int32] = match e {
-        case JsonNumber(b) => BigDecimal.tryToInt32(b)
-        case _ => None
-    }
-
-    def parseAndSum(str:String, len:Int32, result:Int32): Bool =
+    def parseArray(str: String, expected: List[Json.JsonElement]): Bool =
         match parse(str) {
-            case Some(JsonArray(bigs)) =>
-                let sumIsRight = match bigs |> List.traverse(toIntOpt) {
-                    case Some(ints) => List.sum(ints) == result
-                    case _ => false
-                };
-                List.length(bigs)==len and sumIsRight
+            case Some(JsonArray(bigs)) => bigs == expected
             case _ => false
         }
 
-
     @test
-    def testShortArray(): Bool = parseAndSum("[1, 2, 3]", 3, 6)
+    def testShortArray(): Bool =
+        parseArray("[1, 2, 3]", JsonNumber(1ff)::JsonNumber(2ff)::JsonNumber(3ff)::Nil)
 
     @test
     def testLongArray(): Bool =
         region rc {
             let sb = StringBuilder.new(rc);
+            let lst = MutList.new(rc);
             StringBuilder.append!("[1", sb);
+            MutList.push!(JsonNumber(1ff), lst);
             let mx = 60000;
             //[1, 2, 3, 4, ... mx-1]  a string 408887 chars long
-            def loop(n, acc) =
-                if (n >= mx) acc else {
+            def loop(n) =
+                if (n >= mx) () else {
                     StringBuilder.append!(", ${n}", sb);
-                    loop(n+1, acc + n)
+                    MutList.push!(JsonNumber(Int32.toBigDecimal(n)), lst);
+                    loop(n+1)
                 };
-            let result = loop(2, 1);
+            loop(2);
             StringBuilder.append!("]", sb);
             let txt = StringBuilder.toString(sb);
-            parseAndSum(txt, mx-1, result)
+            parseArray(txt, MutList.toList(lst))
         }
 }

--- a/test/TestParse.flix
+++ b/test/TestParse.flix
@@ -79,14 +79,14 @@ mod TestParse {
             StringBuilder.append!("[1", sb);
             let mx = 60000;
             //[1, 2, 3, 4, ... mx-1]  a string 408887 chars long
-            def loop(n) =
-                if (n >= mx) () else {
+            def loop(n, acc) =
+                if (n >= mx) acc else {
                     StringBuilder.append!(", ${n}", sb);
-                    loop(n+1)
+                    loop(n+1, acc + n)
                 };
-            loop(2);
+            let result = loop(2, 1);
             StringBuilder.append!("]", sb);
             let txt = StringBuilder.toString(sb);
-            parseAndSum(txt, mx-1, 1799970000)
+            parseAndSum(txt, mx-1, result)
         }
 }

--- a/test/TestParse.flix
+++ b/test/TestParse.flix
@@ -1,7 +1,7 @@
 mod TestParse {
     use Json.Parse.parse
     use Json.JsonElement.{JsonObject, JsonArray, JsonString, JsonNumber, JsonBool, JsonNull}
-    
+
     @test
     def testEmptyObject01(): Bool = parse("{}") == Some(JsonObject(Map#{}))
 
@@ -18,18 +18,18 @@ mod TestParse {
     def testSingletonString03(): Bool = parse("{\"key\": \"\\u0021\"}") == Some(JsonObject(Map#{"key" => JsonString("!")}))
 
     @test
-    def testDoubleString01(): Bool = 
+    def testDoubleString01(): Bool =
         parse("{\"key1\": \"value1\", \"key2\": \"value2\"}") == Some(JsonObject(Map#{"key1" => JsonString("value1"), "key2" => JsonString("value2")}))
 
     @test
     def testSingletonEmptyArray01(): Bool = parse("{\"key\": []}") == Some(JsonObject(Map#{"key" => JsonArray(Nil)}))
 
     @test
-    def testSingletonSingletonArray01(): Bool = 
+    def testSingletonSingletonArray01(): Bool =
         parse("{\"key\": [\"value\"]}") == Some(JsonObject(Map#{"key" => JsonArray(JsonString("value") :: Nil)}))
 
-    @test 
-    def testSingletonDoubleArray01(): Bool = 
+    @test
+    def testSingletonDoubleArray01(): Bool =
         parse("{\"key\": [\"v1\", \"v2\"]}") == Some(JsonObject(Map#{"key" => JsonArray(JsonString("v1") :: JsonString("v2") :: Nil)}))
 
     @test
@@ -51,4 +51,42 @@ mod TestParse {
     def testEscape01(): Bool = {
         parse("{\"key\": \"\\a\"}") == None
     }
+
+    def toIntOpt(e:Json.JsonElement): Option[Int32] = match e {
+        case JsonNumber(b) => BigDecimal.tryToInt32(b)
+        case _ => None
+    }
+
+    def parseAndSum(str:String, len:Int32, result:Int32): Bool =
+        match parse(str) {
+            case Some(JsonArray(bigs)) =>
+                let sumIsRight = match bigs |> List.traverse(toIntOpt) {
+                    case Some(ints) => List.sum(ints) == result
+                    case _ => false
+                };
+                List.length(bigs)==len and sumIsRight
+            case _ => false
+        }
+
+
+    @test
+    def testShortArray(): Bool = parseAndSum("[1, 2, 3]", 3, 6)
+
+    @test
+    def testLongArray(): Bool =
+        region rc {
+            let sb = StringBuilder.new(rc);
+            StringBuilder.append!("[1", sb);
+            let mx = 60000;
+            //[1, 2, 3, 4, ... mx-1]  a string 408887 chars long
+            def loop(n) =
+                if (n >= mx) () else {
+                    StringBuilder.append!(", ${n}", sb);
+                    loop(n+1)
+                };
+            loop(2);
+            StringBuilder.append!("]", sb);
+            let txt = StringBuilder.toString(sb);
+            parseAndSum(txt, mx-1, 1799970000)
+        }
 }

--- a/test/TestParse.flix
+++ b/test/TestParse.flix
@@ -52,15 +52,12 @@ mod TestParse {
         parse("{\"key\": \"\\a\"}") == None
     }
 
-    def parseArray(str: String, expected: List[Json.JsonElement]): Bool =
-        match parse(str) {
-            case Some(JsonArray(bigs)) => bigs == expected
-            case _ => false
-        }
+    def parseArrayCmp(str: String, expected: List[Json.JsonElement]): Bool =
+        parse(str) == Some(JsonArray(expected))
 
     @test
     def testShortArray(): Bool =
-        parseArray("[1, 2, 3]", JsonNumber(1ff)::JsonNumber(2ff)::JsonNumber(3ff)::Nil)
+        parseArrayCmp("[1, 2, 3]", JsonNumber(1ff)::JsonNumber(2ff)::JsonNumber(3ff)::Nil)
 
     @test
     def testLongArray(): Bool =
@@ -80,6 +77,6 @@ mod TestParse {
             loop(2);
             StringBuilder.append!("]", sb);
             let txt = StringBuilder.toString(sb);
-            parseArray(txt, MutList.toList(lst))
+            parseArrayCmp(txt, MutList.toList(lst))
         }
 }


### PR DESCRIPTION
I tried using this library to parse my ~270 KB json with an array of ~5500 small objects, and it stack overflowed.

This PR changes array parsing to be tail-recursive such that it doesn't choke on long arrays. A test included that generates an array of about 60k elements (400 KB text) and parses it successfully.

The new code might be a bit less idiomatic, so if you want to keep educational value of using monadic `for`, feel free to ignore this PR (or change the code to `for`, if it's possible to do it tail-recursively).